### PR TITLE
Update API URLs to quotify.dazzelr.tech

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "nodemon server.js",
     "build": "echo 'Build complete - Express API ready for deployment'",
     "vercel-build": "echo 'Vercel build complete'",
-    "docs": "echo 'Documentation available at https://quotifyapi.vercel.app'",
+    "docs": "echo 'Documentation available at https://quotify.dazzelr.tech'",
     "test": "echo 'No tests specified yet'",
     "lint": "echo 'No linter configured yet'",
     "prepublishOnly": "npm run build"
@@ -67,7 +67,7 @@
   "bugs": {
     "url": "https://github.com/tanishq-sa/Quotifyapi/issues"
   },
-  "homepage": "https://quotifyapi.vercel.app",
+  "homepage": "https://quotify.dazzelr.tech",
   "engines": {
     "node": ">=14.0.0"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -757,14 +757,14 @@
                                         Get a random quote
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; https://quotifyapi.vercel.app/api/v1/quotes')">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; https://quotify.dazzelr.tech/api/v1/quotes')">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
                                     Copy
                                 </button>
                                         <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
-                                            <code class="text-green-400 text-lg font-mono">curl -H "x-api-key: your-api-key" https://quotifyapi.vercel.app/api/v1/quotes</code>
+                                            <code class="text-green-400 text-lg font-mono">curl -H "x-api-key: your-api-key" https://quotify.dazzelr.tech/api/v1/quotes</code>
                                         </div>
                                     </div>
                             </div>
@@ -775,14 +775,14 @@
                                         Get a specific category
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; https://quotifyapi.vercel.app/api/v1/quotes/category/motivational')">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; https://quotify.dazzelr.tech/api/v1/quotes/category/motivational')">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
                                     Copy
                                 </button>
                                         <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
-                                            <code class="text-blue-400 text-lg font-mono">curl -H "x-api-key: your-api-key" https://quotifyapi.vercel.app/api/v1/quotes/category/motivational</code>
+                                            <code class="text-blue-400 text-lg font-mono">curl -H "x-api-key: your-api-key" https://quotify.dazzelr.tech/api/v1/quotes/category/motivational</code>
                                         </div>
                                     </div>
                             </div>
@@ -793,14 +793,14 @@
                                         Search quotes
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; &quot;https://quotifyapi.vercel.app/api/v1/quotes/search?q=success&quot;')">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'curl -H &quot;x-api-key: your-api-key&quot; &quot;https://quotify.dazzelr.tech/api/v1/quotes/search?q=success&quot;')">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
                                     Copy
                                 </button>
                                         <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
-                                            <code class="text-purple-400 text-lg font-mono">curl -H "x-api-key: your-api-key" "https://quotifyapi.vercel.app/api/v1/quotes/search?q=success"</code>
+                                            <code class="text-purple-400 text-lg font-mono">curl -H "x-api-key: your-api-key" "https://quotify.dazzelr.tech/api/v1/quotes/search?q=success"</code>
                                         </div>
                                     </div>
                                 </div>
@@ -815,7 +815,7 @@
                                         Using Fetch API
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" data-copy-text="// Get random quote\nconst response = await fetch('https://quotifyapi.vercel.app/api/v1/quotes', {\n  headers: {\n    'x-api-key': 'your-api-key'\n  }\n});\nconst data = await response.json();\nconsole.log(data);">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" data-copy-text="// Get random quote\nconst response = await fetch('https://quotify.dazzelr.tech/api/v1/quotes', {\n  headers: {\n    'x-api-key': 'your-api-key'\n  }\n});\nconst data = await response.json();\nconsole.log(data);">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
@@ -823,7 +823,7 @@
                                 </button>
                                         <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
                                             <pre><code class="text-yellow-400 text-lg font-mono">// Get random quote
-const response = await fetch('https://quotifyapi.vercel.app/api/v1/quotes', {
+const response = await fetch('https://quotify.dazzelr.tech/api/v1/quotes', {
   headers: {
     'x-api-key': 'your-api-key'
   }
@@ -844,7 +844,7 @@ console.log(data);</code></pre>
                                         Using Requests Library
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'import requests\n\n# Get random quote\nheaders = {\'x-api-key\': \'your-api-key\'}\nresponse = requests.get(\'https://quotifyapi.vercel.app/api/v1/quotes\', headers=headers)\nquote = response.json()\nprint(quote)')">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, 'import requests\n\n# Get random quote\nheaders = {\'x-api-key\': \'your-api-key\'}\nresponse = requests.get(\'https://quotify.dazzelr.tech/api/v1/quotes\', headers=headers)\nquote = response.json()\nprint(quote)')">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
@@ -855,7 +855,7 @@ console.log(data);</code></pre>
 
 # Get random quote
 headers = {'x-api-key': 'your-api-key'}
-response = requests.get('https://quotifyapi.vercel.app/api/v1/quotes', headers=headers)
+response = requests.get('https://quotify.dazzelr.tech/api/v1/quotes', headers=headers)
 quote = response.json()
 print(quote)</code></pre>
                                         </div>
@@ -872,7 +872,7 @@ print(quote)</code></pre>
                                         Using cURL
                                     </h4>
                             <div class="relative group">
-                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '// Get random quote\n$ch = curl_init();\ncurl_setopt($ch, CURLOPT_URL, \'https://quotifyapi.vercel.app/api/v1/quotes\');\ncurl_setopt($ch, CURLOPT_HTTPHEADER, [\'x-api-key: your-api-key\']);\ncurl_setopt($ch, CURLOPT_RETURNTRANSFER, true);\n$response = curl_exec($ch);\ncurl_close($ch);\n\n$quote = json_decode($response, true);\necho $quote[\'quote\'][\'text\'];')">
+                                        <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '// Get random quote\n$ch = curl_init();\ncurl_setopt($ch, CURLOPT_URL, \'https://quotify.dazzelr.tech/api/v1/quotes\');\ncurl_setopt($ch, CURLOPT_HTTPHEADER, [\'x-api-key: your-api-key\']);\ncurl_setopt($ch, CURLOPT_RETURNTRANSFER, true);\n$response = curl_exec($ch);\ncurl_close($ch);\n\n$quote = json_decode($response, true);\necho $quote[\'quote\'][\'text\'];')">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                     </svg>
@@ -881,7 +881,7 @@ print(quote)</code></pre>
                                         <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
                                             <pre><code class="text-purple-400 text-lg font-mono">// Get random quote
 $ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, 'https://quotifyapi.vercel.app/api/v1/quotes');
+curl_setopt($ch, CURLOPT_URL, 'https://quotify.dazzelr.tech/api/v1/quotes');
 curl_setopt($ch, CURLOPT_HTTPHEADER, ['x-api-key: your-api-key']);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 $response = curl_exec($ch);
@@ -1557,21 +1557,21 @@ quotifyapi --stats</code></pre>
                             <h3 class="font-space text-2xl font-bold text-white">Direct API</h3>
                         </div>
                         <div class="relative group mb-6">
-                            <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '# Base URL: https://quotifyapi.vercel.app\n# All requests require API key authentication')">
+                            <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '# Base URL: https://quotify.dazzelr.tech\n# All requests require API key authentication')">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                 </svg>
                                 Copy
                             </button>
                             <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
-                                <code class="text-blue-400 text-lg font-mono"># Base URL: https://quotifyapi.vercel.app<br># All requests require API key authentication</code>
+                                <code class="text-blue-400 text-lg font-mono"># Base URL: https://quotify.dazzelr.tech<br># All requests require API key authentication</code>
                         </div>
                         </div>
                         <p class="text-gray-300 mb-6 relative">Make HTTP requests directly to the API endpoints with your API key.</p>
                         
                         <h5 class="text-lg font-semibold mb-4 text-white relative">cURL Examples:</h5>
                         <div class="relative group">
-                            <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '# Get random quote\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotifyapi.vercel.app/api\\n\\n# Get motivational quote\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotifyapi.vercel.app/api?type=motivational\\n\\n# Get available types\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotifyapi.vercel.app/api/types\\n\\n# Get API stats\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotifyapi.vercel.app/api/stats')">
+                            <button class="copy-btn absolute top-4 right-4 px-3 py-2 glass-dark hover:bg-white/20 text-gray-300 text-sm font-medium rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-2" onclick="copyToClipboard(this, '# Get random quote\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotify.dazzelr.tech/api\\n\\n# Get motivational quote\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotify.dazzelr.tech/api?type=motivational\\n\\n# Get available types\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotify.dazzelr.tech/api/types\\n\\n# Get API stats\\ncurl -H &quot;x-api-key: YOUR_API_KEY&quot; https://quotify.dazzelr.tech/api/stats')">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                 </svg>
@@ -1579,16 +1579,16 @@ quotifyapi --stats</code></pre>
                             </button>
                             <div class="glass-dark p-6 rounded-2xl overflow-x-auto">
                                 <pre class="text-blue-400 text-sm font-mono"><code># Get random quote
-curl -H "x-api-key: YOUR_API_KEY" https://quotifyapi.vercel.app/api
+curl -H "x-api-key: YOUR_API_KEY" https://quotify.dazzelr.tech/api
 
 # Get motivational quote
-curl -H "x-api-key: YOUR_API_KEY" https://quotifyapi.vercel.app/api?type=motivational
+curl -H "x-api-key: YOUR_API_KEY" https://quotify.dazzelr.tech/api?type=motivational
 
 # Get available types
-curl -H "x-api-key: YOUR_API_KEY" https://quotifyapi.vercel.app/api/types
+curl -H "x-api-key: YOUR_API_KEY" https://quotify.dazzelr.tech/api/types
 
 # Get API stats
-curl -H "x-api-key: YOUR_API_KEY" https://quotifyapi.vercel.app/api/stats</code></pre>
+curl -H "x-api-key: YOUR_API_KEY" https://quotify.dazzelr.tech/api/stats</code></pre>
                         </div>
                         
                         <!-- Decorative elements -->

--- a/public/script.js
+++ b/public/script.js
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (isLocalhost) {
             return `http://localhost:${window.location.port || 3000}`;
         }
-        return 'https://quotifyapi.vercel.app';
+        return 'https://quotify.dazzelr.tech';
     }
 
     // Function to get full URL for requests


### PR DESCRIPTION
Replaced all references to quotifyapi.vercel.app with quotify.dazzelr.tech in package.json, public/index.html, and public/script.js to reflect the new API domain. This ensures documentation, examples, and client code point to the correct API endpoint.